### PR TITLE
[Misc] Make App Component More Succinct

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import {
 } from 'react'
 import Value from './components/Value';
 import ValuesColumn from './components/ValuesColumn';
+import SaveAndLoad from './components/SaveAndLoad/SaveAndLoad';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -83,13 +84,6 @@ function App() {
    */
   const [ randomValue, setRandomValue ] = useState<string>('');
 
-  const saveValuesToLocalStorage = () => {
-    localStorage.setItem(columnKeys.VERY_IMPORTANT_VALUES, JSON.stringify(veryImportantValues));
-    localStorage.setItem(columnKeys.IMPORTANT_VALUES, JSON.stringify(importantValues));
-    localStorage.setItem(columnKeys.NOT_IMPORTANT_VALUES, JSON.stringify(notImportantValues));
-    localStorage.setItem(lockedValuesKey, JSON.stringify(lockedValues));
-  };
-
   const removeDuplicatesAndLoadValues = () => {
     const initialValues: ValuesAndDescriptors = JSON.parse(JSON.stringify(valuesJson));
     const removeDuplicates = (value: string) => {
@@ -124,33 +118,6 @@ function App() {
     setValues(initialValues);
   };
 
-  const loadProgressFromFile = () => {
-    const input = document.createElement('input');
-    input.style.display = 'none';
-    input.type = 'file';
-    document.body.appendChild(input);
-    input.click();
-    input.onchange = (event) => {
-      const fileReader = new FileReader();
-      if (event?.target && (event.target as HTMLInputElement).files?.length) {
-        // Typescript is not recognizing that event and target have
-        // already been null-checked, begrudgingly ts-ignore
-        // @ts-ignore
-        fileReader.readAsText(event.target.files[0], 'UTF-8');
-        fileReader.onload = (event) => {
-          if (event?.target?.result) {
-            const parsedLoadedFile = JSON.parse(event.target.result as string);
-            setVeryImportantValues(parsedLoadedFile[columnKeys.VERY_IMPORTANT_VALUES]);
-            setImportantValues(parsedLoadedFile[columnKeys.IMPORTANT_VALUES]);
-            setNotImportantValues(parsedLoadedFile[columnKeys.NOT_IMPORTANT_VALUES]);
-            setLockedValues(parsedLoadedFile[lockedValuesKey]);
-          }
-          input.remove();
-        }
-      }
-    };
-  };
-
   useEffect(() => {
     removeDuplicatesAndLoadValues();
   }, []);
@@ -163,48 +130,16 @@ function App() {
     <ThemeProvider theme={darkTheme}>
       <CssBaseline />
       <main>
-        <Stack
-          justifyContent="center"
-          direction="row"
-          spacing={2}
-        >
-          <Button
-            variant="contained"
-            color="success"
-            onClick={saveValuesToLocalStorage}
-          >
-            Save Progress
-          </Button>
-          <Button
-            variant="contained"
-            color="success"
-            onClick={() => {
-              saveValuesToLocalStorage();
-              const jsonToSave = {
-                [columnKeys.VERY_IMPORTANT_VALUES]: veryImportantValues,
-                [columnKeys.IMPORTANT_VALUES]: importantValues,
-                [columnKeys.NOT_IMPORTANT_VALUES]: notImportantValues,
-                [lockedValuesKey]: lockedValues,
-              };
-              const element = document.createElement('a');
-              const textFile = new Blob([JSON.stringify(jsonToSave)], {type: 'text/plain'});
-              element.href = URL.createObjectURL(textFile);
-              element.download = 'values.json';
-              document.body.appendChild(element); 
-              element.click();
-              element.remove();
-            }}
-          >
-            Save Progress To File
-          </Button>
-          <Button
-            variant="contained"
-            color="success"
-            onClick={loadProgressFromFile}
-          >
-            Load Progress From File
-          </Button>
-        </Stack>
+        <SaveAndLoad
+          lockedValues={lockedValues}
+          veryImportantValues={veryImportantValues}
+          importantValues={importantValues}
+          notImportantValues={notImportantValues}
+          setVeryImportantValues={setVeryImportantValues}
+          setImportantValues={setImportantValues}
+          setNotImportantValues={setNotImportantValues}
+          setLockedValues={setLockedValues}
+        />
         {(randomValue !== '')
           && (
             <>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import Grid from '@mui/material/Unstable_Grid2';
 import Stack from '@mui/material/Stack';
 import CssBaseline from '@mui/material/CssBaseline';
 import valuesJson from './data/values-and-descriptors.json';
+import { columnKeys, lockedValuesKey } from './constants';
 import './App.css'
 
 export type ValuesAndDescriptors = {
@@ -34,14 +35,6 @@ export const LockedValuesContext = createContext({
   lockedValues: [] as Array<string>,
   setLockedValues: () => {},
 });
-
-const columnKeys = {
-  VERY_IMPORTANT_VALUES: 'veryImportantValues',
-  IMPORTANT_VALUES: 'importantValues',
-  NOT_IMPORTANT_VALUES: 'notImportantValues',
-};
-
-const lockedValuesKey = 'lockedValues';
 
 /**
  * Delete the chosen Value from the original set of Values and sort it into

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import Grid from '@mui/material/Unstable_Grid2';
 import Stack from '@mui/material/Stack';
 import CssBaseline from '@mui/material/CssBaseline';
 import valuesJson from './data/values-and-descriptors.json';
-import { columnKeys, lockedValuesKey } from './constants';
+import { columns, columnKeys, lockedValuesKey } from './constants';
 import './App.css'
 
 export type ValuesAndDescriptors = {
@@ -24,12 +24,6 @@ const darkTheme = createTheme({
     mode: 'dark',
   },
 });
-
-export const columns: Array<string> = [
-  'Very Important',
-  'Important',
-  'Not Important',
-];
 
 export const LockedValuesContext = createContext({
   lockedValues: [] as Array<string>,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,11 +13,8 @@ import Stack from '@mui/material/Stack';
 import CssBaseline from '@mui/material/CssBaseline';
 import valuesJson from './data/values-and-descriptors.json';
 import { columns, columnKeys, lockedValuesKey } from './constants';
+import { ValuesAndDescriptors } from './types';
 import './App.css'
-
-export type ValuesAndDescriptors = {
-  [value: string]: string;
-}
 
 const darkTheme = createTheme({
   palette: {

--- a/src/components/SaveAndLoad/SaveAndLoad.tsx
+++ b/src/components/SaveAndLoad/SaveAndLoad.tsx
@@ -1,0 +1,26 @@
+import {} from 'react';
+import { columnKeys, lockedValuesKey } from '../../constants';
+import { ValuesAndDescriptors } from '../../types';
+
+interface SaveAndLoadProps {
+  lockedValues: Array<string>;
+  veryImportantValues: ValuesAndDescriptors;
+  importantValues: ValuesAndDescriptors;
+  notImportantValues: ValuesAndDescriptors;
+};
+
+export default function SaveAndLoad(props: SaveAndLoadProps) {
+  const {
+    lockedValues,
+    veryImportantValues,
+    importantValues,
+    notImportantValues,
+  } = props;
+
+  const saveValuesToLocalStorage = () => {
+    localStorage.setItem(columnKeys.VERY_IMPORTANT_VALUES, JSON.stringify(veryImportantValues));
+    localStorage.setItem(columnKeys.IMPORTANT_VALUES, JSON.stringify(importantValues));
+    localStorage.setItem(columnKeys.NOT_IMPORTANT_VALUES, JSON.stringify(notImportantValues));
+    localStorage.setItem(lockedValuesKey, JSON.stringify(lockedValues));
+  };
+};

--- a/src/components/SaveAndLoad/SaveAndLoad.tsx
+++ b/src/components/SaveAndLoad/SaveAndLoad.tsx
@@ -10,7 +10,7 @@ interface SaveAndLoadProps {
   setVeryImportantValues: React.Dispatch<React.SetStateAction<ValuesAndDescriptors>>;
   setImportantValues: React.Dispatch<React.SetStateAction<ValuesAndDescriptors>>;
   setNotImportantValues: React.Dispatch<React.SetStateAction<ValuesAndDescriptors>>;
-  setLockedValues: React.Dispatch<React.SetStateAction<ValuesAndDescriptors>>;
+  setLockedValues: React.Dispatch<React.SetStateAction<Array<string>>>;
 };
 
 export default function SaveAndLoad(props: SaveAndLoadProps) {

--- a/src/components/SaveAndLoad/SaveAndLoad.tsx
+++ b/src/components/SaveAndLoad/SaveAndLoad.tsx
@@ -7,6 +7,10 @@ interface SaveAndLoadProps {
   veryImportantValues: ValuesAndDescriptors;
   importantValues: ValuesAndDescriptors;
   notImportantValues: ValuesAndDescriptors;
+  setVeryImportantValues: React.Dispatch<React.SetStateAction<ValuesAndDescriptors>>;
+  setImportantValues: React.Dispatch<React.SetStateAction<ValuesAndDescriptors>>;
+  setNotImportantValues: React.Dispatch<React.SetStateAction<ValuesAndDescriptors>>;
+  setLockedValues: React.Dispatch<React.SetStateAction<ValuesAndDescriptors>>;
 };
 
 export default function SaveAndLoad(props: SaveAndLoadProps) {
@@ -15,7 +19,38 @@ export default function SaveAndLoad(props: SaveAndLoadProps) {
     veryImportantValues,
     importantValues,
     notImportantValues,
+    setVeryImportantValues,
+    setImportantValues,
+    setNotImportantValues,
+    setLockedValues,
   } = props;
+
+  const loadProgressFromFile = () => {
+    const input = document.createElement('input');
+    input.style.display = 'none';
+    input.type = 'file';
+    document.body.appendChild(input);
+    input.click();
+    input.onchange = (event) => {
+      const fileReader = new FileReader();
+      if (event?.target && (event.target as HTMLInputElement).files?.length) {
+        // Typescript is not recognizing that event and target have
+        // already been null-checked, begrudgingly ts-ignore
+        // @ts-ignore
+        fileReader.readAsText(event.target.files[0], 'UTF-8');
+        fileReader.onload = (event) => {
+          if (event?.target?.result) {
+            const parsedLoadedFile = JSON.parse(event.target.result as string);
+            setVeryImportantValues(parsedLoadedFile[columnKeys.VERY_IMPORTANT_VALUES]);
+            setImportantValues(parsedLoadedFile[columnKeys.IMPORTANT_VALUES]);
+            setNotImportantValues(parsedLoadedFile[columnKeys.NOT_IMPORTANT_VALUES]);
+            setLockedValues(parsedLoadedFile[lockedValuesKey]);
+          }
+          input.remove();
+        }
+      }
+    };
+  };
 
   const saveValuesToLocalStorage = () => {
     localStorage.setItem(columnKeys.VERY_IMPORTANT_VALUES, JSON.stringify(veryImportantValues));

--- a/src/components/SaveAndLoad/SaveAndLoad.tsx
+++ b/src/components/SaveAndLoad/SaveAndLoad.tsx
@@ -1,4 +1,6 @@
 import {} from 'react';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
 import { columnKeys, lockedValuesKey } from '../../constants';
 import { ValuesAndDescriptors } from '../../types';
 
@@ -58,4 +60,49 @@ export default function SaveAndLoad(props: SaveAndLoadProps) {
     localStorage.setItem(columnKeys.NOT_IMPORTANT_VALUES, JSON.stringify(notImportantValues));
     localStorage.setItem(lockedValuesKey, JSON.stringify(lockedValues));
   };
+
+  return (
+    <Stack
+      justifyContent="center"
+      direction="row"
+      spacing={2}
+    >
+      <Button
+        variant="contained"
+        color="success"
+        onClick={saveValuesToLocalStorage}
+      >
+        Save Progress
+      </Button>
+      <Button
+        variant="contained"
+        color="success"
+        onClick={() => {
+          saveValuesToLocalStorage();
+          const jsonToSave = {
+            [columnKeys.VERY_IMPORTANT_VALUES]: veryImportantValues,
+            [columnKeys.IMPORTANT_VALUES]: importantValues,
+            [columnKeys.NOT_IMPORTANT_VALUES]: notImportantValues,
+            [lockedValuesKey]: lockedValues,
+          };
+          const element = document.createElement('a');
+          const textFile = new Blob([JSON.stringify(jsonToSave)], {type: 'text/plain'});
+          element.href = URL.createObjectURL(textFile);
+          element.download = 'values.json';
+          document.body.appendChild(element); 
+          element.click();
+          element.remove();
+        }}
+      >
+        Save Progress To File
+      </Button>
+      <Button
+        variant="contained"
+        color="success"
+        onClick={loadProgressFromFile}
+      >
+        Load Progress From File
+      </Button>
+    </Stack>
+  );
 };

--- a/src/components/ValuesColumn/ValuesColumn.tsx
+++ b/src/components/ValuesColumn/ValuesColumn.tsx
@@ -2,7 +2,8 @@ import { DragEvent, useState } from 'react';
 import Grid from '@mui/material/Unstable_Grid2';
 import Typography from '@mui/material/Typography';
 import Value from '../Value';
-import { columns, ValuesAndDescriptors } from '../../App';
+import { columns } from '../../constants';
+import { ValuesAndDescriptors } from '../../App';
 import './ValuesColumn.css';
 
 interface ValuesColumnProps {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,7 @@
+export const columnKeys = {
+  VERY_IMPORTANT_VALUES: 'veryImportantValues',
+  IMPORTANT_VALUES: 'importantValues',
+  NOT_IMPORTANT_VALUES: 'notImportantValues',
+};
+
+export const lockedValuesKey = 'lockedValues';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,9 @@
+export const columns: Array<string> = [
+  'Very Important',
+  'Important',
+  'Not Important',
+];
+
 export const columnKeys = {
   VERY_IMPORTANT_VALUES: 'veryImportantValues',
   IMPORTANT_VALUES: 'importantValues',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,3 @@
+export type ValuesAndDescriptors = {
+  [value: string]: string;
+}


### PR DESCRIPTION
While doing a refresher on React concepts in the course:

https://frontendmasters.com/courses/complete-react-v8/

Specifically the section about Component Composition:

https://react-v8.holt.courses/lessons/core-react-concepts/component-composition

Brian mentions how as a general rule of thumb, ~300 lines of code in a React component might be a bit too long. Breaking such a long component into smaller components, even if those smaller components aren't going to be re-used, is advised.

Looking back at my `App.tsx` with that in-mind, it was looking unwieldy, so I decided to port the section of the app containing all the buttons for Saving & Loading into its own component.

This also lead to further reducing the LoC in the App component, thanks to moving Types and Constants into their own `.ts` files, since they were now being used in multiple components.